### PR TITLE
Package library versions for netstandard2.0 and netcoreapp3.1.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         dotnet: [
-          { framework: netstandard2.0, version: 2.1.806 },
+          { framework: netcoreapp2.1, version: 2.1.806 },
           { framework: netcoreapp3.1, version: 3.1.202 }
         ]
 
@@ -31,5 +31,5 @@ jobs:
 
       - name: Build and tests library
         run: |
-          dotnet build --configuration Release ./src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
+          dotnet build --configuration Release --framework netstandard2.0 ./src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
           dotnet test --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,5 @@ jobs:
 
       - name: Build and tests library
         run: |
-          dotnet build --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj /p:Framework=${{ matrix.dotnet.framework }}
-          dotnet test --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj /p:Framework=${{ matrix.dotnet.framework }}
+          dotnet build --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj /p:FrameworkForTest=${{ matrix.dotnet.framework }}
+          dotnet test --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj /p:FrameworkForTest=${{ matrix.dotnet.framework }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,5 @@ jobs:
 
       - name: Build and tests library
         run: |
-          dotnet build --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
+#          dotnet build --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
           dotnet test --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,17 +16,13 @@ jobs:
       matrix:
         dotnet: [
           { framework: netcoreapp2.1, version: 2.1.806 },
-          { framework: netcoreapp3.1, version: 3.1.104 }
+          { framework: netcoreapp3.1, version: 3.1.100 }
         ]
 
     name: ${{ matrix.dotnet.framework }} – build and test
 
     steps:
       - uses: actions/checkout@master
-
-      - run: |
-          echo ${{ matrix.dotnet.framework }}
-          echo ${{ matrix.dotnet.version }}
 
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,5 @@ jobs:
 
       - name: Build and tests library
         run: |
-          dotnet build --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
-          dotnet test --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj
+          dotnet build --configuration Release ./src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
+          dotnet test --configuration Release ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,5 @@ jobs:
 
       - name: Build and tests library
         run: |
+          dotnet build --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj /p:Framework=${{ matrix.dotnet.framework }}
           dotnet test --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj /p:Framework=${{ matrix.dotnet.framework }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,4 @@ jobs:
 
       - name: Build and tests library
         run: |
-          dotnet build --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj /p:FrameworkForTest=${{ matrix.dotnet.framework == 'netcoreapp2.1'}}
           dotnet test --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj /p:FrameworkForTest=${{ matrix.dotnet.framework == 'netcoreapp2.1'}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,5 @@ jobs:
 
       - name: Build and tests library
         run: |
-          dotnet build --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj /p:FrameworkForTest=true
-          dotnet test --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj /p:FrameworkForTest=true
+          dotnet build --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj /p:FrameworkForTest=${{ matrix.dotnet.framework == 'netcoreapp2.1'}}
+          dotnet test --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj /p:FrameworkForTest=${{ matrix.dotnet.framework == 'netcoreapp2.1'}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,4 @@ jobs:
 
       - name: Build and tests library
         run: |
-          dotnet build --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj /p:Framework=${{ matrix.dotnet.framework }}
           dotnet test --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj /p:Framework=${{ matrix.dotnet.framework }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         dotnet: [
-          { framework: netcoreapp2.1, version: 2.1.806 },
+          { framework: netstandard2.0, version: 2.1.806 },
           { framework: netcoreapp3.1, version: 3.1.202 }
         ]
 
@@ -31,4 +31,5 @@ jobs:
 
       - name: Build and tests library
         run: |
+          dotnet build --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
           dotnet test --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,5 @@ jobs:
 
       - name: Build and tests library
         run: |
+          dotnet build --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
           dotnet test --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,6 @@ jobs:
   run-tests:
     runs-on: ubuntu-latest
 
-    if: ${{ !contains(github.event.commits[0].message, '[skip ci]') }}
-
     strategy:
       matrix:
         dotnet: [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,4 @@ jobs:
 
       - name: Build and tests library
         run: |
-          dotnet test --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj
+          dotnet test --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj /p:Framework=${{ matrix.dotnet.framework }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,4 @@ jobs:
 
       - name: Build and tests library
         run: |
-          dotnet test --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj /p:FrameworkForTest=${{ matrix.dotnet.framework == 'netcoreapp2.1'}}
+          dotnet test --configuration Release ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj /p:FrameworkForTest=${{ matrix.dotnet.framework == 'netcoreapp2.1'}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,4 @@ jobs:
 
       - name: Build and tests library
         run: |
-          dotnet test --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj /p:FrameworkForTest=${{ matrix.dotnet.framework == 'netcoreapp2.1'}}
+          dotnet test --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj /p:Framework=${{ matrix.dotnet.framework }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         dotnet: [
           { framework: netcoreapp2.1, version: 2.1.806 },
-          { framework: netcoreapp3.1, version: 3.1.202 }
+          { framework: netcoreapp3.1, version: 3.1.104 }
         ]
 
     name: Build and test with dotnet framework ${{ matrix.dotnet.framework }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,4 @@ jobs:
 
       - name: Build and tests library
         run: |
-#          dotnet build --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
           dotnet test --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,18 @@ on:
 
 jobs:
   build-and-test:
-    name: Build and test library
     runs-on: ubuntu-latest
 
     if: ${{ !contains(github.event.commits[0].message, '[skip ci]') }}
+
+    strategy:
+      matrix:
+        dotnet: [
+          { framework: netcoreapp2.1, version: 2.1.806 },
+          { framework: netcoreapp3.1, version: 3.1.202 }
+        ]
+
+    name: Build and test with dotnet framework ${{ matrix.dotnet.framework }}
 
     steps:
       - uses: actions/checkout@master
@@ -19,9 +27,9 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: "3.1.100"
+          dotnet-version:  ${{ matrix.dotnet.version }}
 
       - name: Build and tests library
         run: |
-          dotnet build --configuration Release ./src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
-          dotnet test --configuration Release ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj
+          dotnet build --configuration Release --framework ${{ matrix.dotnet.version }} ./src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
+          dotnet test --configuration Release --framework ${{ matrix.dotnet.version }} ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,5 @@ jobs:
 
       - name: Build and tests library
         run: |
-          dotnet test --configuration Release ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj /p:FrameworkForTest=${{ matrix.dotnet.framework == 'netcoreapp2.1'}}
+          dotnet build --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj /p:FrameworkForTest=${{ matrix.dotnet.framework == 'netcoreapp2.1'}}
+          dotnet test --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj /p:FrameworkForTest=${{ matrix.dotnet.framework == 'netcoreapp2.1'}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,14 @@ jobs:
           { framework: netcoreapp3.1, version: 3.1.104 }
         ]
 
-    name: Build and test with dotnet framework ${{ matrix.dotnet.framework }}
+    name: ${{ matrix.dotnet.framework }} – build and test
 
     steps:
       - uses: actions/checkout@master
+
+      - run: |
+          echo ${{ matrix.dotnet.framework }}
+          echo ${{ matrix.dotnet.version }}
 
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       matrix:
         dotnet: [
-          { framework: netcoreapp2.1, version: 2.1.806 },
-          { framework: netcoreapp3.1, version: 3.1.202 }
+          { build-framework: netstandard2.0, test-framework: netcoreapp2.1, version: 2.1.806 },
+          { build-framework: netcoreapp3.1, test-framework: netcoreapp3.1, version: 3.1.202 }
         ]
 
     name: ${{ matrix.dotnet.framework }} – build and test
@@ -31,5 +31,5 @@ jobs:
 
       - name: Build and tests library
         run: |
-          dotnet build --configuration Release --framework netstandard2.0 ./src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
-          dotnet test --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj
+          dotnet build --configuration Release --framework ${{ matrix.dotnet.build-framework }} ./src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
+          dotnet test --configuration Release --framework ${{ matrix.dotnet.test-framework }} ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           { build-framework: netcoreapp3.1, test-framework: netcoreapp3.1, version: 3.1.202 }
         ]
 
-    name: ${{ matrix.dotnet.framework }} – build and test
+    name: ${{ matrix.dotnet.build-framework }} – build and test
 
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,4 +32,4 @@ jobs:
       - name: Build and tests library
         run: |
           dotnet build --configuration Release ./src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
-          dotnet test --configuration Release ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj
+          dotnet test --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - "!master"
 
 jobs:
-  build-and-test:
+  run-tests:
     runs-on: ubuntu-latest
 
     if: ${{ !contains(github.event.commits[0].message, '[skip ci]') }}
@@ -19,7 +19,7 @@ jobs:
           { framework: netcoreapp3.1, version: 3.1.202 }
         ]
 
-    name: ${{ matrix.dotnet.framework }} – build and test
+    name: ${{ matrix.dotnet.framework }} – run tests
 
     steps:
       - uses: actions/checkout@master
@@ -29,6 +29,6 @@ jobs:
         with:
           dotnet-version:  ${{ matrix.dotnet.version }}
 
-      - name: Build and tests library
+      - name: Run tests
         run: |
           dotnet test --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj /p:Framework=${{ matrix.dotnet.framework }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         dotnet: [
           { framework: netcoreapp2.1, version: 2.1.806 },
-          { framework: netcoreapp3.1, version: 3.1.100 }
+          { framework: netcoreapp3.1, version: 3.1.202 }
         ]
 
     name: ${{ matrix.dotnet.framework }} – build and test
@@ -31,5 +31,5 @@ jobs:
 
       - name: Build and tests library
         run: |
-          dotnet build --configuration Release --framework ${{ matrix.dotnet.version }} ./src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
-          dotnet test --configuration Release --framework ${{ matrix.dotnet.version }} ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj
+          dotnet build --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
+          dotnet test --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,4 @@ jobs:
 
       - name: Build and tests library
         run: |
-          dotnet test --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj /p:Framework=${{ matrix.dotnet.framework }}
+          dotnet test --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,11 @@ jobs:
     strategy:
       matrix:
         dotnet: [
-          { build-framework: netstandard2.0, test-framework: netcoreapp2.1, version: 2.1.806 },
-          { build-framework: netcoreapp3.1, test-framework: netcoreapp3.1, version: 3.1.202 }
+          { framework: netcoreapp2.1, version: 2.1.806 },
+          { framework: netcoreapp3.1, version: 3.1.202 }
         ]
 
-    name: ${{ matrix.dotnet.build-framework }} – build and test
+    name: ${{ matrix.dotnet.framework }} – build and test
 
     steps:
       - uses: actions/checkout@master
@@ -31,5 +31,4 @@ jobs:
 
       - name: Build and tests library
         run: |
-          dotnet build --configuration Release --framework ${{ matrix.dotnet.build-framework }} ./src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
-          dotnet test --configuration Release --framework ${{ matrix.dotnet.test-framework }} ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj
+          dotnet test --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj /p:Framework=${{ matrix.dotnet.framework }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,5 @@ jobs:
 
       - name: Build and tests library
         run: |
-          dotnet build --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj /p:FrameworkForTest=${{ matrix.dotnet.framework }}
-          dotnet test --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj /p:FrameworkForTest=${{ matrix.dotnet.framework }}
+          dotnet build --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj /p:FrameworkForTest=true
+          dotnet test --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj /p:FrameworkForTest=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,4 @@ jobs:
 
       - name: Build and tests library
         run: |
-          dotnet build --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
           dotnet test --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -6,11 +6,19 @@ on:
       - master
 
 jobs:
-  build-and-test:
-    name: Build and test library
+  run-tests:
     runs-on: ubuntu-latest
 
     if: ${{ !contains(github.event.commits[0].message, '[skip ci]') }}
+
+    strategy:
+      matrix:
+        dotnet: [
+          { framework: netcoreapp2.1, version: 2.1.806 },
+          { framework: netcoreapp3.1, version: 3.1.202 }
+        ]
+
+    name: ${{ matrix.dotnet.framework }} – run tests
 
     steps:
       - uses: actions/checkout@master
@@ -18,19 +26,18 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: "3.1.100"
+          dotnet-version:  ${{ matrix.dotnet.version }}
 
-      - name: Build and test library
+      - name: Run tests
         run: |
-          dotnet build --configuration Release ./src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
-          dotnet test --configuration Release ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj
+          dotnet test --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj /p:Framework=${{ matrix.dotnet.framework }}
 
 
   release:
     name: Create release
     runs-on: ubuntu-latest
 
-    needs: build-and-test
+    needs: run-tests
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -9,8 +9,6 @@ jobs:
   run-tests:
     runs-on: ubuntu-latest
 
-    if: ${{ !contains(github.event.commits[0].message, '[skip ci]') }}
-
     strategy:
       matrix:
         dotnet: [

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,38 @@ on:
     types: [published]
 
 jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+
+    if: ${{ !contains(github.event.commits[0].message, '[skip ci]') }}
+
+    strategy:
+      matrix:
+        dotnet: [
+        { framework: netcoreapp2.1, version: 2.1.806 },
+        { framework: netcoreapp3.1, version: 3.1.202 }
+        ]
+
+    name: ${{ matrix.dotnet.framework }} – run tests
+
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version:  ${{ matrix.dotnet.version }}
+
+      - name: Run tests
+        run: |
+          dotnet test --configuration Release --framework ${{ matrix.dotnet.framework }} ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj /p:Framework=${{ matrix.dotnet.framework }}
+
+
   build-and-publish:
     name: Build and publish library to NuGet
     runs-on: ubuntu-latest
+
+    needs: run-tests
 
     steps:
       - uses: actions/checkout@master
@@ -35,14 +64,14 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: "3.1.100"
+          dotnet-version: 3.1.202
 
       - name: Build and publish library to NuGet
         run: |
           dotnet build --configuration Release ./src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
-          dotnet test --configuration Release ./src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj
           dotnet pack --no-restore --no-build --configuration Release --version-suffix "${{ steps.extract-version-suffix.outputs.version_suffix }}" --output out/ ./src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
           dotnet nuget push out/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}
+
       - uses: actions/upload-artifact@master
         with:
           name: NuGet package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,6 @@ jobs:
   run-tests:
     runs-on: ubuntu-latest
 
-    if: ${{ !contains(github.event.commits[0].message, '[skip ci]') }}
-
     strategy:
       matrix:
         dotnet: [

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,9 +93,10 @@ jobs:
       - name: Get package
         id: get-package
         run: |
-          echo "::set-output name=package::$(ls out/)"
+          echo "::set-output name=package::$(ls out/*.nupkg)"
+          echo "::set-output name=symbols::$(ls out/*.snupkg)"
 
-      - name: Upload release assets
+      - name: Upload package asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -103,4 +104,14 @@ jobs:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: ./out/${{ steps.get-package.outputs.package }}
           asset_name: ${{ steps.get-package.outputs.package }}
+          asset_content_type: application/zip
+
+      - name: Upload symbols asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./out/${{ steps.get-package.outputs.symbols }}
+          asset_name: ${{ steps.get-package.outputs.symbols }}
           asset_content_type: application/zip

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Dodo.HttpClient.ResiliencePolicies library
 
+[![nuget](https://img.shields.io/nuget/v/Dodo.HttpClient.ResiliencePolicies?label=NuGet)](https://www.nuget.org/packages/Dodo.HttpClient.ResiliencePolicies)
 ![master](https://github.com/dodopizza/httpclient-resilience-policies/workflows/master/badge.svg)
-![release](https://github.com/dodopizza/httpclient-resilience-policies/workflows/release/badge.svg)
 
 The main goal of this library is to provide unified http request retrying policies for the HttpClient that just works.
 

--- a/src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj
+++ b/src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(FrameworkForTest)' != 'true'">netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
-    <TargetFramework Condition="'$(FrameworkForTest)' == 'true'">netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj
+++ b/src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(FrameworkForTest)' != 'netcoreapp2.1'">netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
-    <TargetFramework Condition="'$(FrameworkForTest)' == 'netcoreapp2.1'">netcoreapp2.1</TargetFramework>
+    <TargetFrameworks Condition="'$(FrameworkForTest)' != 'true'">netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(FrameworkForTest)' == 'true'">netcoreapp2.1</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj
+++ b/src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(Framework)' != 'netcoreapp2.1'">netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
-    <TargetFramework Condition="'$(Framework)' == 'netcoreapp2.1'">netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj
+++ b/src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(TargetFramework)' != 'netcoreapp2.1'">netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
-    <TargetFramework Condition="'$(TargetFramework)' == 'netcoreapp2.1'">netcoreapp2.1</TargetFramework>
+    <TargetFrameworks Condition="'$(Framework)' != 'netcoreapp2.1'">netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(Framework)' == 'netcoreapp2.1'">netcoreapp2.1</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj
+++ b/src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(FrameworkForTest)' != 'netcoreapp2.1'">netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(FrameworkForTest)' == 'netcoreapp2.1'">netcoreapp2.1</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj
+++ b/src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(Framework)' != 'netcoreapp2.1'">netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(Framework)' == 'netcoreapp2.1'">netcoreapp2.1</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj
+++ b/src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <LangVersion>8.0</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj
+++ b/src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(Framework)' != 'netcoreapp2.1'">netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
-    <TargetFramework Condition="'$(Framework)' == 'netcoreapp2.1'">netcoreapp2.1</TargetFramework>
+    <TargetFrameworks Condition="'$(TargetFramework)' != 'netcoreapp2.1'">netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(TargetFramework)' == 'netcoreapp2.1'">netcoreapp2.1</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
+++ b/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(FrameworkForTest)' != 'netcoreapp2.1'">netstandard2.0;netcoreapp3.1</TargetFrameworks>
-    <TargetFramework Condition="'$(FrameworkForTest)' == 'netcoreapp2.1'">netstandard2.0</TargetFramework>
+    <TargetFrameworks Condition="'$(FrameworkForTest)' != 'true'">netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(FrameworkForTest)' == 'true'">netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <VersionPrefix>1.0.1</VersionPrefix>
     <Version Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix)</Version>

--- a/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
+++ b/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks Condition="'$(Framework)' != 'netcoreapp2.1'">netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <TargetFramework Condition="'$(Framework)' == 'netcoreapp2.1'">netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
-    <VersionPrefix>1.0.1</VersionPrefix>
+    <VersionPrefix>1.0.2</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />

--- a/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
+++ b/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(FrameworkForTest)' != 'true'">netstandard2.0;netcoreapp3.1</TargetFrameworks>
-    <TargetFramework Condition="'$(FrameworkForTest)' == 'true'">netstandard2.0</TargetFramework>
+    <TargetFrameworks Condition="'$(Framework)' != 'netcoreapp2.1'">netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(Framework)' == 'netcoreapp2.1'">netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <VersionPrefix>1.0.1</VersionPrefix>
     <Version Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix)</Version>

--- a/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
+++ b/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(Framework)' != 'netcoreapp2.1'">netstandard2.0;netcoreapp3.1</TargetFrameworks>
-    <TargetFramework Condition="'$(Framework)' == 'netcoreapp2.1'">netstandard2.0</TargetFramework>
+    <TargetFrameworks Condition="'$(TargetFramework)' != 'netcoreapp2.1'">netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(TargetFramework)' == 'netcoreapp2.1'">netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <VersionPrefix>1.0.1</VersionPrefix>
     <Version Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix)</Version>

--- a/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
+++ b/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <VersionPrefix>1.0.1</VersionPrefix>
     <Version Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix)</Version>

--- a/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
+++ b/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <LangVersion>8.0</LangVersion>
     <VersionPrefix>1.0.1</VersionPrefix>
     <Version Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix)</Version>
     <Version Condition=" '$(Version)' == '' ">$(VersionPrefix)</Version>

--- a/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
+++ b/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
@@ -1,12 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(Framework)' != 'netcoreapp2.1'">netstandard2.0;netcoreapp3.1</TargetFrameworks>
-    <TargetFramework Condition="'$(Framework)' == 'netcoreapp2.1'">netstandard2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <VersionPrefix>1.0.1</VersionPrefix>
     <Version Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix)</Version>
     <Version Condition=" '$(Version)' == '' ">$(VersionPrefix)</Version>
-
     <PackageId>Dodo.HttpClient.ResiliencePolicies</PackageId>
     <Authors>Dodo Pizza</Authors>
     <Company>Dodo Pizza</Company>

--- a/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
+++ b/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
@@ -4,18 +4,6 @@
     <TargetFramework Condition="'$(Framework)' == 'netcoreapp2.1'">netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <VersionPrefix>1.0.1</VersionPrefix>
-    <PackageId>Dodo.HttpClient.ResiliencePolicies</PackageId>
-    <Authors>Dodo Pizza</Authors>
-    <Company>Dodo Pizza</Company>
-    <Description>The main goal of this library is to provide unified http request retrying policies for the HttpClient that just works. Actually this library wraps awesome Polly library with the predefined settings to allow developers to use it as is without a deep dive to Polly.</Description>
-    <RepositoryUrl>https://github.com/dodopizza/httpclient-resilience-policies</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <Copyright>Copyright 2020 Dodo Pizza</Copyright>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/dodopizza/httpclient-resilience-policies/master/LICENSE</PackageLicenseUrl>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
@@ -24,10 +12,34 @@
     <PackageReference Include="Polly" Version="7.2.0" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.0" />
   </ItemGroup>
-  <PropertyGroup Label="NuspecProperties">
-    <NeutralLanguage>en-US</NeutralLanguage>
+  <ItemGroup>
+    <None Include="..\..\dodopizza-logo.png">
+      <PackagePath>\</PackagePath>
+      <Pack>true</Pack>
+      <Link>dodopizza-logo.png</Link>
+    </None>
+    <None Include="..\..\LICENSE">
+      <PackagePath>\</PackagePath>
+      <Pack>true</Pack>
+      <Link>LICENSE</Link>
+    </None>
+  </ItemGroup>
+  <PropertyGroup Label="nuspec">
+    <PackageId>Dodo.HttpClient.ResiliencePolicies</PackageId>
     <AssemblyTitle>Dodo.HttpClient.ResiliencePolicies</AssemblyTitle>
-    <PackageIconUrl>https://raw.github.com/dodopizza/httpclient-resilience-policies/master/dodopizza-logo.png</PackageIconUrl>
+    <Authors>Dodo Pizza</Authors>
+    <Company>Dodo Pizza</Company>
+    <Description>The main goal of this library is to provide unified http request retrying policies for the HttpClient that just works. Actually this library wraps awesome Polly library with the predefined settings to allow developers to use it as is without a deep dive to Polly.</Description>
+    <RepositoryUrl>https://github.com/dodopizza/httpclient-resilience-policies</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <Copyright>Copyright 2020 Dodo Pizza</Copyright>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PackageIcon>dodopizza-logo.png</PackageIcon>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageTags>HttpClient Resilience Policy CircuitBreaker Retry Timeout</PackageTags>
+    <NeutralLanguage>en-US</NeutralLanguage>
   </PropertyGroup>
 </Project>

--- a/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
+++ b/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <VersionPrefix>1.0.1</VersionPrefix>
     <Version Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix)</Version>

--- a/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
+++ b/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(Framework)' != 'netcoreapp2.1'">netstandard2.0;netcoreapp3.1</TargetFrameworks>
-    <TargetFramework Condition="'$(Framework)' == 'netcoreapp2.1'">netstandard2.0</TargetFramework>
+    <TargetFrameworks Condition="'$(FrameworkForTest)' != 'netcoreapp2.1'">netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(FrameworkForTest)' == 'netcoreapp2.1'">netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <VersionPrefix>1.0.1</VersionPrefix>
     <Version Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix)</Version>

--- a/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
+++ b/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(Framework)' != 'netcoreapp2.1'">netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(Framework)' == 'netcoreapp2.1'">netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <VersionPrefix>1.0.1</VersionPrefix>
     <Version Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix)</Version>

--- a/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
+++ b/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
@@ -23,6 +23,11 @@
       <Pack>true</Pack>
       <Link>LICENSE</Link>
     </None>
+    <None Include="..\..\README.md">
+      <PackagePath>\</PackagePath>
+      <Pack>true</Pack>
+      <Link>README.md</Link>
+    </None>
   </ItemGroup>
   <PropertyGroup Label="nuspec">
     <PackageId>Dodo.HttpClient.ResiliencePolicies</PackageId>
@@ -39,6 +44,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageIcon>dodopizza-logo.png</PackageIcon>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>HttpClient Resilience Policy CircuitBreaker Retry Timeout</PackageTags>
     <NeutralLanguage>en-US</NeutralLanguage>
   </PropertyGroup>

--- a/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
+++ b/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
@@ -1,11 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(TargetFramework)' != 'netcoreapp2.1'">netstandard2.0;netcoreapp3.1</TargetFrameworks>
-    <TargetFramework Condition="'$(TargetFramework)' == 'netcoreapp2.1'">netstandard2.0</TargetFramework>
+    <TargetFrameworks Condition="'$(Framework)' != 'netcoreapp2.1'">netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(Framework)' == 'netcoreapp2.1'">netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <VersionPrefix>1.0.1</VersionPrefix>
-    <Version Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix)</Version>
-    <Version Condition=" '$(Version)' == '' ">$(VersionPrefix)</Version>
     <PackageId>Dodo.HttpClient.ResiliencePolicies</PackageId>
     <Authors>Dodo Pizza</Authors>
     <Company>Dodo Pizza</Company>
@@ -14,6 +12,10 @@
     <RepositoryType>git</RepositoryType>
     <Copyright>Copyright 2020 Dodo Pizza</Copyright>
     <PackageLicenseUrl>https://raw.githubusercontent.com/dodopizza/httpclient-resilience-policies/master/LICENSE</PackageLicenseUrl>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />

--- a/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
+++ b/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(Framework)' != 'netcoreapp2.1'">netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(Framework)' == 'netcoreapp2.1'">netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <VersionPrefix>1.0.1</VersionPrefix>
     <Version Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix)</Version>

--- a/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
+++ b/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <VersionPrefix>1.0.1</VersionPrefix>
     <Version Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix)</Version>


### PR DESCRIPTION
- Support two target frameworks: netstandard2.0 and netcoreapp3.1 (#29)
- Update CI to run tests using both LTS SDKs: 2.1 and 3.1 (#28)
- Add PDB files and symbols for NuGet package (#30)
- Add documentation to NuGet package (#23)
- Replace deprecated nuspec properties for license and icon with up to date versions (#22)