### PR TITLE
HttpClientBuilderExtensions.AddJsonClient: add support usage optional parameter `clientName`.

### DIFF
--- a/src/Dodo.HttpClient.ResiliencePolicies.Tests/Fakes/MockJsonClient.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies.Tests/Fakes/MockJsonClient.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Dodo.HttpClient.ResiliencePolicies.Tests.Fakes
+{
+	public interface IMockJsonClient
+	{ }
+
+	public class MockJsonClient : IMockJsonClient
+	{ }
+}

--- a/src/Dodo.HttpClient.ResiliencePolicies.Tests/HttpClientBuilderExtensionsTests.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies.Tests/HttpClientBuilderExtensionsTests.cs
@@ -1,0 +1,62 @@
+using Dodo.HttpClient.ResiliencePolicies.Tests.Fakes;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Dodo.HttpClient.ResiliencePolicies.Tests
+{
+	[TestFixture]
+	public class HttpClientBuilderExtensionsTests
+	{
+		[Test]
+		public async Task AddJsonClient_WithNullClientName_ConfiguresDefaultJsonClient()
+		{
+			// Arrange
+			var serviceCollection = new ServiceCollection();
+
+			// Act1
+			serviceCollection.AddJsonClient<IMockJsonClient, MockJsonClient>(
+				new Uri("http://example.com/"),
+				HttpClientSettings.Default());
+
+			var services = serviceCollection.BuildServiceProvider();
+
+			var factory = services.GetRequiredService<IHttpClientFactory>();
+
+			// Act2
+			var client = factory.CreateClient(nameof(IMockJsonClient));
+
+			// Assert
+			Assert.NotNull(client);
+			Assert.AreEqual("http://example.com/", client.BaseAddress.AbsoluteUri);
+		}
+
+		[Test]
+		public async Task AddJsonClient_WithSpecificClientName_ConfiguresSpecificJsonClient()
+		{
+			// Arrange
+			var serviceCollection = new ServiceCollection();
+
+			// Act1
+			serviceCollection.AddJsonClient<IMockJsonClient, MockJsonClient>(
+				new Uri("http://example.com/"),
+				HttpClientSettings.Default(),
+				"specificName");
+
+			var services = serviceCollection.BuildServiceProvider();
+
+			var factory = services.GetRequiredService<IHttpClientFactory>();
+
+			// Act2
+			var client = factory.CreateClient("specificName");
+
+			// Assert
+			Assert.NotNull(client);
+			Assert.AreEqual("http://example.com/", client.BaseAddress.AbsoluteUri);
+		}
+	}
+}

--- a/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
+++ b/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks Condition="'$(Framework)' != 'netcoreapp2.1'">netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <TargetFramework Condition="'$(Framework)' == 'netcoreapp2.1'">netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
-    <VersionPrefix>1.0.2</VersionPrefix>
+    <VersionPrefix>1.0.3</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />

--- a/src/Dodo.HttpClient.ResiliencePolicies/HttpClientBuilderExtensions.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies/HttpClientBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -30,13 +30,20 @@ namespace Dodo.HttpClient.ResiliencePolicies
 			string clientName = null) where TClientInterface : class
 			where TClientImplementation : class, TClientInterface
 		{
-			var httpClientBuilder = sc.AddHttpClient<TClientInterface, TClientImplementation>(client =>
-				{
-					client.BaseAddress = baseAddress;
-					client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-					client.Timeout = settings.HttpClientTimeout;
-				})
-				.AddDefaultPolicies(settings);
+			Action<System.Net.Http.HttpClient> defaultClient = (client) => 
+			{
+				client.BaseAddress = baseAddress;
+				client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+				client.Timeout = settings.HttpClientTimeout;
+			};
+
+			IHttpClientBuilder httpClientBuilder;
+			if (!string.IsNullOrEmpty(clientName))
+				httpClientBuilder = sc.AddHttpClient<TClientInterface, TClientImplementation>(clientName, defaultClient);
+			else
+				httpClientBuilder = sc.AddHttpClient<TClientInterface, TClientImplementation>(defaultClient);
+
+			httpClientBuilder.AddDefaultPolicies(settings);
 
 			return httpClientBuilder;
 		}

--- a/src/Dodo.HttpClient.ResiliencePolicies/HttpClientBuilderExtensions.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies/HttpClientBuilderExtensions.cs
@@ -37,11 +37,9 @@ namespace Dodo.HttpClient.ResiliencePolicies
 				client.Timeout = settings.HttpClientTimeout;
 			};
 
-			IHttpClientBuilder httpClientBuilder;
-			if (!string.IsNullOrEmpty(clientName))
-				httpClientBuilder = sc.AddHttpClient<TClientInterface, TClientImplementation>(clientName, defaultClient);
-			else
-				httpClientBuilder = sc.AddHttpClient<TClientInterface, TClientImplementation>(defaultClient);
+			IHttpClientBuilder httpClientBuilder = string.IsNullOrEmpty(clientName)
+				? httpClientBuilder = sc.AddHttpClient<TClientInterface, TClientImplementation>(defaultClient)
+				: httpClientBuilder = sc.AddHttpClient<TClientInterface, TClientImplementation>(clientName, defaultClient);
 
 			httpClientBuilder.AddDefaultPolicies(settings);
 

--- a/src/Dodo.HttpClient.ResiliencePolicies/HttpClientBuilderExtensions.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies/HttpClientBuilderExtensions.cs
@@ -38,8 +38,8 @@ namespace Dodo.HttpClient.ResiliencePolicies
 			};
 
 			IHttpClientBuilder httpClientBuilder = string.IsNullOrEmpty(clientName)
-				? httpClientBuilder = sc.AddHttpClient<TClientInterface, TClientImplementation>(defaultClient)
-				: httpClientBuilder = sc.AddHttpClient<TClientInterface, TClientImplementation>(clientName, defaultClient);
+				? sc.AddHttpClient<TClientInterface, TClientImplementation>(defaultClient)
+				: sc.AddHttpClient<TClientInterface, TClientImplementation>(clientName, defaultClient);
 
 			httpClientBuilder.AddDefaultPolicies(settings);
 


### PR DESCRIPTION
tests: HttpClientBuilderExtensionsTests: add 2 test case on new features

Issue #25 