### PR TITLE
Overall timeout policy feature

### DIFF
--- a/src/Dodo.HttpClient.ResiliencePolicies.Tests/CircuitBreakerPolicyTests.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies.Tests/CircuitBreakerPolicyTests.cs
@@ -21,7 +21,7 @@ namespace Dodo.HttpClient.ResiliencePolicies.Tests
 				sleepDurationProvider: i => TimeSpan.FromMilliseconds(50));
 			var wrapper = Create.HttpClientWrapperWrapperBuilder
 				.WithStatusCode(HttpStatusCode.ServiceUnavailable)
-				.WithHttpClientTimeout(TimeSpan.FromSeconds(5))
+				.WithTimeoutOverall(TimeSpan.FromSeconds(5))
 				.WithCircuitBreakerSettings(BuildCircuitBreakerSettings(minimumThroughput))
 				.WithRetrySettings(retrySettings)
 				.Please();
@@ -43,7 +43,7 @@ namespace Dodo.HttpClient.ResiliencePolicies.Tests
 			var wrapper = Create.HttpClientWrapperWrapperBuilder
 				.WithHostAndStatusCode("ru-prod.com", HttpStatusCode.ServiceUnavailable)
 				.WithHostAndStatusCode("ee-prod.com", HttpStatusCode.OK)
-				.WithHttpClientTimeout(TimeSpan.FromSeconds(5))
+				.WithTimeoutOverall(TimeSpan.FromSeconds(5))
 				.WithCircuitBreakerSettings(BuildCircuitBreakerSettings(minimumThroughput))
 				.WithRetrySettings(retrySettings)
 				.PleaseHostSpecific();

--- a/src/Dodo.HttpClient.ResiliencePolicies.Tests/DSL/HttpClientWrapperBuilder.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies.Tests/DSL/HttpClientWrapperBuilder.cs
@@ -16,9 +16,8 @@ namespace Dodo.HttpClient.ResiliencePolicies.Tests.DSL
 		private readonly Dictionary<string, HttpStatusCode> _hostsResponseCodes = new Dictionary<string, HttpStatusCode>();
 		private IRetrySettings _retrySettings;
 		private ICircuitBreakerSettings _circuitBreakerSettings;
-		private TimeSpan _httpClientTimeout = TimeSpan.FromDays(1);
 		private TimeSpan _timeoutPerTry = TimeSpan.FromDays(1);
-		private TimeSpan? _timeoutOverall = null;
+		private TimeSpan _timeoutOverall = TimeSpan.FromDays(1);
 		private TimeSpan _responseLatency = TimeSpan.Zero;
 
 		public HttpClientWrapperBuilder WithStatusCode(HttpStatusCode statusCode)
@@ -30,12 +29,6 @@ namespace Dodo.HttpClient.ResiliencePolicies.Tests.DSL
 		public HttpClientWrapperBuilder WithHostAndStatusCode(string host, HttpStatusCode statusCode)
 		{
 			_hostsResponseCodes.Add(host, statusCode);
-			return this;
-		}
-
-		public HttpClientWrapperBuilder WithHttpClientTimeout(TimeSpan httpClientTimeout)
-		{
-			_httpClientTimeout = httpClientTimeout;
 			return this;
 		}
 
@@ -110,7 +103,6 @@ namespace Dodo.HttpClient.ResiliencePolicies.Tests.DSL
 				);
 
 			return new HttpClientSettings(
-				httpClientTimeout: _httpClientTimeout,
 				timeoutPerTry: _timeoutPerTry,
 				timeoutOverall: _timeoutOverall,
 				retrySettings: _retrySettings ?? JitterRetrySettings.Default(),

--- a/src/Dodo.HttpClient.ResiliencePolicies.Tests/DSL/HttpClientWrapperBuilder.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies.Tests/DSL/HttpClientWrapperBuilder.cs
@@ -12,7 +12,7 @@ namespace Dodo.HttpClientResiliencePolicies.Tests.DSL
 	public sealed class HttpClientWrapperBuilder
 	{
 		private const string ClientName = "TestClient";
-		private Uri _uri = new Uri("http://localhost");
+		private readonly Uri _uri = new Uri("http://localhost");
 		private readonly Dictionary<string, HttpStatusCode> _hostsResponseCodes = new Dictionary<string, HttpStatusCode>();
 		private IRetrySettings _retrySettings;
 		private ICircuitBreakerSettings _circuitBreakerSettings;
@@ -103,8 +103,8 @@ namespace Dodo.HttpClientResiliencePolicies.Tests.DSL
 				);
 
 			return new HttpClientSettings(
-				timeoutPerTry: _timeoutPerTry,
 				timeoutOverall: _timeoutOverall,
+				timeoutPerTry: _timeoutPerTry,
 				retrySettings: _retrySettings ?? JitterRetrySettings.Default(),
 				circuitBreakerSettings: defaultCircuitBreakerSettings);
 		}

--- a/src/Dodo.HttpClient.ResiliencePolicies.Tests/TimeoutPolicyTests.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies.Tests/TimeoutPolicyTests.cs
@@ -31,7 +31,6 @@ namespace Dodo.HttpClient.ResiliencePolicies.Tests
 			Assert.AreEqual(retryCount + 1, wrapper.NumberOfCalls);
 		}
 
-
 		[Test]
 		public void Should_fail_on_HttpClient_timeout()
 		{
@@ -65,6 +64,98 @@ namespace Dodo.HttpClient.ResiliencePolicies.Tests
 				await wrapper.Client.GetAsync("http://localhost"));
 
 			Assert.AreEqual(2, wrapper.NumberOfCalls);
+		}
+
+		[Test]
+		public void When_timeoutOverall_greater_httpClientTimeout_Then_httpClientTimeout_equal_timeoutOverall()
+		{
+			var overallTimeout = TimeSpan.FromMilliseconds(300);
+			var httpClientTimeout = TimeSpan.FromMilliseconds(200);
+
+			var wrapper = Create.HttpClientWrapperWrapperBuilder
+				.WithStatusCode(HttpStatusCode.OK)
+				.WithResponseLatency(TimeSpan.FromMilliseconds(100))
+				.WithHttpClientTimeout(httpClientTimeout)
+				.WithTimeoutOverall(overallTimeout)
+				.Please();
+
+			Assert.AreEqual(overallTimeout, wrapper.Client.Timeout);
+		}
+
+		[Test]
+		public void When_timeoutOverall_less_httpClientTimeout_Then_httpClientTimeout_not_changed()
+		{
+			var overallTimeout = TimeSpan.FromMilliseconds(200);
+			var httpClientTimeout = TimeSpan.FromMilliseconds(300);
+
+			var wrapper = Create.HttpClientWrapperWrapperBuilder
+				.WithStatusCode(HttpStatusCode.OK)
+				.WithResponseLatency(TimeSpan.FromMilliseconds(100))
+				.WithHttpClientTimeout(httpClientTimeout)
+				.WithTimeoutOverall(overallTimeout)
+				.Please();
+
+			Assert.AreEqual(httpClientTimeout, wrapper.Client.Timeout);
+		}
+
+		[Test]
+		public void Should_catchTimeout_because_of_overall_timeout()
+		{
+			var wrapper = Create.HttpClientWrapperWrapperBuilder
+				.WithStatusCode(HttpStatusCode.OK)
+				.WithResponseLatency(TimeSpan.FromMilliseconds(200))
+				.WithTimeoutOverall(TimeSpan.FromMilliseconds(100))
+				.Please();
+
+			Assert.CatchAsync<TimeoutRejectedException>(async () =>
+				await wrapper.Client.GetAsync("http://localhost"));
+		}
+
+		[Test]
+		public void Should_catchTimeout_1_times_because_of_overall_timeout_less_than_per_try_timeout()
+		{
+			var overallTimeout = TimeSpan.FromMilliseconds(100);
+			var perTryTimeout = TimeSpan.FromMilliseconds(200);
+
+			var retrySettings = new SimpleRetrySettings(
+				5,
+				sleepDurationProvider: i => TimeSpan.FromMilliseconds(200));
+			var wrapper = Create.HttpClientWrapperWrapperBuilder
+				.WithStatusCode(HttpStatusCode.OK)
+				.WithResponseLatency(TimeSpan.FromMilliseconds(300))
+				.WithTimeoutPerTry(perTryTimeout)
+				.WithTimeoutOverall(overallTimeout) // less
+				.WithRetrySettings(retrySettings)
+				.Please();
+
+			Assert.CatchAsync<TimeoutRejectedException>(async () =>
+				await wrapper.Client.GetAsync("http://localhost"));
+
+			Assert.AreEqual(1, wrapper.NumberOfCalls);
+		}
+
+		[Test]
+		public void When_overall_timeout_greated_than_summ_perTrials_Should_retry_5_times_200_status_code_because_of_per_try_timeout_and__()
+		{
+			const int retryCount = 5;
+			var perTryTimeout = TimeSpan.FromMilliseconds(100);
+			var overallTimeout = TimeSpan.FromSeconds(2);
+			 
+			var retrySettings = new SimpleRetrySettings(
+				retryCount,
+				sleepDurationProvider: i => TimeSpan.FromMilliseconds(200));
+			var wrapper = Create.HttpClientWrapperWrapperBuilder
+				.WithStatusCode(HttpStatusCode.OK)
+				.WithResponseLatency(TimeSpan.FromMilliseconds(200))
+				.WithTimeoutPerTry(perTryTimeout)
+				.WithTimeoutOverall(overallTimeout)
+				.WithRetrySettings(retrySettings)
+				.Please();
+
+			Assert.CatchAsync<TimeoutRejectedException>(async () =>
+				await wrapper.Client.GetAsync("http://localhost"));
+
+			Assert.AreEqual(retryCount + 1, wrapper.NumberOfCalls);
 		}
 	}
 }

--- a/src/Dodo.HttpClient.ResiliencePolicies/Defaults.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies/Defaults.cs
@@ -6,6 +6,7 @@ namespace Dodo.HttpClient.ResiliencePolicies
 		{
 			public const int HttpClientTimeoutInMilliseconds = 10000;
 			public const int TimeoutPerTryInMilliseconds = 2000;
+			public const int TimeoutOverallInMillicesons = 100000;
 		}
 
 		public static class Retry

--- a/src/Dodo.HttpClient.ResiliencePolicies/Defaults.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies/Defaults.cs
@@ -4,9 +4,8 @@ namespace Dodo.HttpClientResiliencePolicies
 	{
 		public static class Timeout
 		{
-			public const int HttpClientTimeoutInMilliseconds = 10000;
+			public const int TimeoutOverallInMilliseconds = 50000;
 			public const int TimeoutPerTryInMilliseconds = 2000;
-			public const int TimeoutOverallInMillicesons = 100000;
 		}
 
 		public static class Retry

--- a/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
+++ b/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks Condition="'$(Framework)' != 'netcoreapp2.1'">netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <TargetFramework Condition="'$(Framework)' == 'netcoreapp2.1'">netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
-    <VersionPrefix>1.0.3</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />

--- a/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
+++ b/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks Condition="'$(Framework)' != 'netcoreapp2.1'">netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <TargetFramework Condition="'$(Framework)' == 'netcoreapp2.1'">netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>2.0.0</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />

--- a/src/Dodo.HttpClient.ResiliencePolicies/HttpClientBuilderExtensions.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies/HttpClientBuilderExtensions.cs
@@ -30,11 +30,12 @@ namespace Dodo.HttpClientResiliencePolicies
 			string clientName = null) where TClientInterface : class
 			where TClientImplementation : class, TClientInterface
 		{
+			var delta = TimeSpan.FromMilliseconds(1000);
 			Action<HttpClient> defaultClient = (client) =>
 			{
 				client.BaseAddress = baseAddress;
 				client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-				client.Timeout = settings.HttpClientTimeout;
+				client.Timeout = settings.TimeoutOverall + delta;
 			};
 
 			var httpClientBuilder = string.IsNullOrEmpty(clientName)

--- a/src/Dodo.HttpClient.ResiliencePolicies/HttpClientBuilderExtensions.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies/HttpClientBuilderExtensions.cs
@@ -68,13 +68,8 @@ namespace Dodo.HttpClient.ResiliencePolicies
 			this IHttpClientBuilder clientBuilder,
 			HttpClientSettings settings)
 		{
-			if (settings.TimeoutOverall != null)
-			{
-				clientBuilder = clientBuilder
-					.AddTimeoutPolicy(settings.TimeoutOverall.Value);
-			};
-
 			return clientBuilder
+				.AddTimeoutPolicy(settings.TimeoutOverall)
 				.AddRetryPolicy(settings.RetrySettings)
 				.AddCircuitBreakerPolicy(settings.CircuitBreakerSettings)
 				.AddTimeoutPolicy(settings.TimeoutPerTry);
@@ -102,13 +97,8 @@ namespace Dodo.HttpClient.ResiliencePolicies
 			this IHttpClientBuilder clientBuilder,
 			HttpClientSettings settings)
 		{
-			if (settings.TimeoutOverall != null)
-			{
-				clientBuilder = clientBuilder
-					.AddTimeoutPolicy(settings.TimeoutOverall.Value);
-			};
-
 			return clientBuilder
+				.AddTimeoutPolicy(settings.TimeoutOverall)
 				.AddRetryPolicy(settings.RetrySettings)
 				.AddHostSpecificCircuitBreakerPolicy(settings.CircuitBreakerSettings)
 				.AddTimeoutPolicy(settings.TimeoutPerTry);

--- a/src/Dodo.HttpClient.ResiliencePolicies/HttpClientBuilderExtensions.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies/HttpClientBuilderExtensions.cs
@@ -68,6 +68,12 @@ namespace Dodo.HttpClient.ResiliencePolicies
 			this IHttpClientBuilder clientBuilder,
 			HttpClientSettings settings)
 		{
+			if (settings.TimeoutOverall != null)
+			{
+				clientBuilder = clientBuilder
+					.AddTimeoutPolicy(settings.TimeoutOverall.Value);
+			};
+
 			return clientBuilder
 				.AddRetryPolicy(settings.RetrySettings)
 				.AddCircuitBreakerPolicy(settings.CircuitBreakerSettings)
@@ -96,6 +102,12 @@ namespace Dodo.HttpClient.ResiliencePolicies
 			this IHttpClientBuilder clientBuilder,
 			HttpClientSettings settings)
 		{
+			if (settings.TimeoutOverall != null)
+			{
+				clientBuilder = clientBuilder
+					.AddTimeoutPolicy(settings.TimeoutOverall.Value);
+			};
+
 			return clientBuilder
 				.AddRetryPolicy(settings.RetrySettings)
 				.AddHostSpecificCircuitBreakerPolicy(settings.CircuitBreakerSettings)

--- a/src/Dodo.HttpClient.ResiliencePolicies/HttpClientSettings.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies/HttpClientSettings.cs
@@ -6,7 +6,6 @@ namespace Dodo.HttpClientResiliencePolicies
 {
 	public class HttpClientSettings
 	{
-		public TimeSpan HttpClientTimeout { get; }
 		public TimeSpan TimeoutPerTry { get; }
 		public TimeSpan TimeoutOverall { get; }
 		public IRetrySettings RetrySettings { get; }
@@ -38,14 +37,10 @@ namespace Dodo.HttpClientResiliencePolicies
 			ICircuitBreakerSettings circuitBreakerSettings,
 			TimeSpan timeoutOverall)
 		{
-			var delta = TimeSpan.FromMilliseconds(1000);
-
-			TimeoutOverall = timeoutOverall;
-			HttpClientTimeout = timeoutOverall + delta;
-
 			TimeoutPerTry = timeoutPerTry;
 			RetrySettings = retrySettings;
 			CircuitBreakerSettings = circuitBreakerSettings;
+			TimeoutOverall = timeoutOverall;
 		}
 
 		public static HttpClientSettings Default() =>

--- a/src/Dodo.HttpClient.ResiliencePolicies/HttpClientSettings.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies/HttpClientSettings.cs
@@ -8,15 +8,14 @@ namespace Dodo.HttpClient.ResiliencePolicies
 	{
 		public TimeSpan HttpClientTimeout { get; }
 		public TimeSpan TimeoutPerTry { get; }
-		public TimeSpan? TimeoutOverall { get; }
+		public TimeSpan TimeoutOverall { get; }
 		public IRetrySettings RetrySettings { get; }
 		public ICircuitBreakerSettings CircuitBreakerSettings { get; }
 
 		public HttpClientSettings(
-			TimeSpan httpClientTimeout,
 			TimeSpan timeoutPerTry,
 			int retryCount,
-			TimeSpan? timeoutOverall = null) : this(httpClientTimeout, timeoutPerTry,
+			TimeSpan timeoutOverall) : this(timeoutPerTry,
 			new JitterRetrySettings(retryCount),
 			ResiliencePolicies.CircuitBreakerSettings.CircuitBreakerSettings.Default(),
 			timeoutOverall)
@@ -26,7 +25,6 @@ namespace Dodo.HttpClient.ResiliencePolicies
 		public HttpClientSettings(
 			IRetrySettings retrySettings,
 			ICircuitBreakerSettings circuitBreakerSettings) : this(
-			TimeSpan.FromMilliseconds(Defaults.Timeout.HttpClientTimeoutInMilliseconds),
 			TimeSpan.FromMilliseconds(Defaults.Timeout.TimeoutPerTryInMilliseconds),
 			retrySettings,
 			circuitBreakerSettings,
@@ -35,17 +33,15 @@ namespace Dodo.HttpClient.ResiliencePolicies
 		}
 
 		public HttpClientSettings(
-			TimeSpan httpClientTimeout,
 			TimeSpan timeoutPerTry,
 			IRetrySettings retrySettings,
 			ICircuitBreakerSettings circuitBreakerSettings,
-			TimeSpan? timeoutOverall = null)
+			TimeSpan timeoutOverall)
 		{
-			TimeoutOverall = timeoutOverall;
+			var delta = TimeSpan.FromMilliseconds(1000);
 
-			HttpClientTimeout = (timeoutOverall == null || httpClientTimeout > timeoutOverall.Value)
-				? httpClientTimeout
-				: timeoutOverall.Value;
+			TimeoutOverall = timeoutOverall;
+			HttpClientTimeout = timeoutOverall + delta;
 
 			TimeoutPerTry = timeoutPerTry;
 			RetrySettings = retrySettings;

--- a/src/Dodo.HttpClient.ResiliencePolicies/HttpClientSettings.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies/HttpClientSettings.cs
@@ -6,8 +6,8 @@ namespace Dodo.HttpClientResiliencePolicies
 {
 	public class HttpClientSettings
 	{
-		public TimeSpan TimeoutPerTry { get; }
 		public TimeSpan TimeoutOverall { get; }
+		public TimeSpan TimeoutPerTry { get; }
 		public IRetrySettings RetrySettings { get; }
 		public ICircuitBreakerSettings CircuitBreakerSettings { get; }
 

--- a/src/Dodo.HttpClient.ResiliencePolicies/HttpClientSettings.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies/HttpClientSettings.cs
@@ -12,35 +12,40 @@ namespace Dodo.HttpClientResiliencePolicies
 		public ICircuitBreakerSettings CircuitBreakerSettings { get; }
 
 		public HttpClientSettings(
+			TimeSpan timeoutOverall,
 			TimeSpan timeoutPerTry,
-			int retryCount,
-			TimeSpan timeoutOverall) : this(timeoutPerTry,
-			new JitterRetrySettings(retryCount),
-			HttpClientResiliencePolicies.CircuitBreakerSettings.CircuitBreakerSettings.Default(),
-			timeoutOverall)
+			int retryCount
+			) : this(
+				timeoutOverall,
+				timeoutPerTry,
+				new JitterRetrySettings(retryCount),
+				HttpClientResiliencePolicies.CircuitBreakerSettings.CircuitBreakerSettings.Default()
+			)
 		{
 		}
 
 		public HttpClientSettings(
 			IRetrySettings retrySettings,
 			ICircuitBreakerSettings circuitBreakerSettings) : this(
-			TimeSpan.FromMilliseconds(Defaults.Timeout.TimeoutPerTryInMilliseconds),
-			retrySettings,
-			circuitBreakerSettings,
-			TimeSpan.FromMilliseconds(Defaults.Timeout.TimeoutOverallInMillicesons))
+				TimeSpan.FromMilliseconds(Defaults.Timeout.TimeoutOverallInMilliseconds),
+				TimeSpan.FromMilliseconds(Defaults.Timeout.TimeoutPerTryInMilliseconds),
+				retrySettings,
+				circuitBreakerSettings
+			)
 		{
 		}
 
 		public HttpClientSettings(
+			TimeSpan timeoutOverall,
 			TimeSpan timeoutPerTry,
 			IRetrySettings retrySettings,
-			ICircuitBreakerSettings circuitBreakerSettings,
-			TimeSpan timeoutOverall)
+			ICircuitBreakerSettings circuitBreakerSettings
+			)
 		{
+			TimeoutOverall = timeoutOverall;
 			TimeoutPerTry = timeoutPerTry;
 			RetrySettings = retrySettings;
 			CircuitBreakerSettings = circuitBreakerSettings;
-			TimeoutOverall = timeoutOverall;
 		}
 
 		public static HttpClientSettings Default() =>

--- a/src/Dodo.HttpClient.ResiliencePolicies/HttpClientSettings.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies/HttpClientSettings.cs
@@ -17,7 +17,7 @@ namespace Dodo.HttpClientResiliencePolicies
 			int retryCount,
 			TimeSpan timeoutOverall) : this(timeoutPerTry,
 			new JitterRetrySettings(retryCount),
-			HttpClientResiliencePolicies.CircuitBreakerSettings.CircuitBreakerSettings.Default())
+			HttpClientResiliencePolicies.CircuitBreakerSettings.CircuitBreakerSettings.Default(),
 			timeoutOverall)
 		{
 		}


### PR DESCRIPTION
HttpClientSettings: add new optional parameter TimeoutOverall
When HttpClientTimeout less than TimeoutOverall then HttpClientTimeout equal as TimeoutOverall.

tests: HttpClientWrapperBuilder using AddJsonClient instead of a direct call AddHttpClient
add 5 test cases of Overall Timeout parameter

Issue #13 