### PR TITLE
Fix namespace clash by changing the Root Namespace

### DIFF
--- a/src/Dodo.HttpClient.ResiliencePolicies.Tests/CircuitBreakerPolicyTests.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies.Tests/CircuitBreakerPolicyTests.cs
@@ -1,13 +1,13 @@
 using System;
 using System.Net;
 using System.Threading.Tasks;
-using Dodo.HttpClient.ResiliencePolicies.CircuitBreakerSettings;
-using Dodo.HttpClient.ResiliencePolicies.RetrySettings;
-using Dodo.HttpClient.ResiliencePolicies.Tests.DSL;
+using Dodo.HttpClientResiliencePolicies.CircuitBreakerSettings;
+using Dodo.HttpClientResiliencePolicies.RetrySettings;
+using Dodo.HttpClientResiliencePolicies.Tests.DSL;
 using NUnit.Framework;
 using Polly.CircuitBreaker;
 
-namespace Dodo.HttpClient.ResiliencePolicies.Tests
+namespace Dodo.HttpClientResiliencePolicies.Tests
 {
 	[TestFixture]
 	public class CircuitBreakerTests

--- a/src/Dodo.HttpClient.ResiliencePolicies.Tests/DSL/Create.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies.Tests/DSL/Create.cs
@@ -1,4 +1,4 @@
-namespace Dodo.HttpClient.ResiliencePolicies.Tests.DSL
+namespace Dodo.HttpClientResiliencePolicies.Tests.DSL
 {
 	public static class Create
 	{

--- a/src/Dodo.HttpClient.ResiliencePolicies.Tests/DSL/HttpClientWrapper.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies.Tests/DSL/HttpClientWrapper.cs
@@ -1,9 +1,8 @@
-using Dodo.HttpClient.ResiliencePolicies.Tests.Fakes;
+using System.Net.Http;
+using Dodo.HttpClientResiliencePolicies.Tests.Fakes;
 
-namespace Dodo.HttpClient.ResiliencePolicies.Tests.DSL
+namespace Dodo.HttpClientResiliencePolicies.Tests.DSL
 {
-	using HttpClient = System.Net.Http.HttpClient;
-
 	public class HttpClientWrapper
 	{
 		private readonly HttpClient _client;

--- a/src/Dodo.HttpClient.ResiliencePolicies.Tests/DSL/HttpClientWrapperBuilder.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies.Tests/DSL/HttpClientWrapperBuilder.cs
@@ -2,12 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
-using Dodo.HttpClient.ResiliencePolicies.CircuitBreakerSettings;
-using Dodo.HttpClient.ResiliencePolicies.RetrySettings;
-using Dodo.HttpClient.ResiliencePolicies.Tests.Fakes;
+using Dodo.HttpClientResiliencePolicies.CircuitBreakerSettings;
+using Dodo.HttpClientResiliencePolicies.RetrySettings;
+using Dodo.HttpClientResiliencePolicies.Tests.Fakes;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Dodo.HttpClient.ResiliencePolicies.Tests.DSL
+namespace Dodo.HttpClientResiliencePolicies.Tests.DSL
 {
 	public sealed class HttpClientWrapperBuilder
 	{

--- a/src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj
+++ b/src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj
@@ -5,6 +5,7 @@
     <TargetFramework Condition="'$(Framework)' == 'netcoreapp2.1'">netcoreapp2.1</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <IsPackable>false</IsPackable>
+    <RootNamespace>Dodo.HttpClientResiliencePolicies.Tests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Dodo.HttpClient.ResiliencePolicies.Tests/Fakes/MockHttpMessageHandler.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies.Tests/Fakes/MockHttpMessageHandler.cs
@@ -5,7 +5,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Dodo.HttpClient.ResiliencePolicies.Tests.Fakes
+namespace Dodo.HttpClientResiliencePolicies.Tests.Fakes
 {
 	public class MockHttpMessageHandler : HttpMessageHandler
 	{

--- a/src/Dodo.HttpClient.ResiliencePolicies.Tests/Fakes/MockJsonClient.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies.Tests/Fakes/MockJsonClient.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Dodo.HttpClient.ResiliencePolicies.Tests.Fakes
+namespace Dodo.HttpClientResiliencePolicies.Tests.Fakes
 {
 	public interface IMockJsonClient
 	{ }

--- a/src/Dodo.HttpClient.ResiliencePolicies.Tests/Helper.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies.Tests/Helper.cs
@@ -1,9 +1,9 @@
 using System.Net.Http;
 using System.Threading.Tasks;
 
-namespace Dodo.HttpClient.ResiliencePolicies.Tests
+namespace Dodo.HttpClientResiliencePolicies.Tests
 {
-	using HttpClient = System.Net.Http.HttpClient;
+	using HttpClient = HttpClient;
 
 	public static class Helper
 	{

--- a/src/Dodo.HttpClient.ResiliencePolicies.Tests/HttpClientBuilderExtensionsTests.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies.Tests/HttpClientBuilderExtensionsTests.cs
@@ -1,13 +1,10 @@
-using Dodo.HttpClient.ResiliencePolicies.Tests.Fakes;
+using System;
+using System.Net.Http;
+using Dodo.HttpClientResiliencePolicies.Tests.Fakes;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Net.Http;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace Dodo.HttpClient.ResiliencePolicies.Tests
+namespace Dodo.HttpClientResiliencePolicies.Tests
 {
 	[TestFixture]
 	public class HttpClientBuilderExtensionsTests

--- a/src/Dodo.HttpClient.ResiliencePolicies.Tests/RetryPolicyTests.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies.Tests/RetryPolicyTests.cs
@@ -4,12 +4,12 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Dodo.HttpClient.ResiliencePolicies.RetrySettings;
-using Dodo.HttpClient.ResiliencePolicies.Tests.DSL;
+using Dodo.HttpClientResiliencePolicies.RetrySettings;
+using Dodo.HttpClientResiliencePolicies.Tests.DSL;
 using NUnit.Framework;
 using Polly;
 
-namespace Dodo.HttpClient.ResiliencePolicies.Tests
+namespace Dodo.HttpClientResiliencePolicies.Tests
 {
 	[TestFixture]
 	public class RetryPolicyTests

--- a/src/Dodo.HttpClient.ResiliencePolicies.Tests/TimeoutPolicyTests.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies.Tests/TimeoutPolicyTests.cs
@@ -1,12 +1,12 @@
 using System;
 using System.Net;
 using System.Threading.Tasks;
-using Dodo.HttpClient.ResiliencePolicies.RetrySettings;
-using Dodo.HttpClient.ResiliencePolicies.Tests.DSL;
+using Dodo.HttpClientResiliencePolicies.RetrySettings;
+using Dodo.HttpClientResiliencePolicies.Tests.DSL;
 using NUnit.Framework;
 using Polly.Timeout;
 
-namespace Dodo.HttpClient.ResiliencePolicies.Tests
+namespace Dodo.HttpClientResiliencePolicies.Tests
 {
 	[TestFixture]
 	public class TimeoutPolicyTests

--- a/src/Dodo.HttpClient.ResiliencePolicies/CircuitBreakerSettings/CircuitBreakerSettings.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies/CircuitBreakerSettings/CircuitBreakerSettings.cs
@@ -2,7 +2,7 @@ using System;
 using System.Net.Http;
 using Polly;
 
-namespace Dodo.HttpClient.ResiliencePolicies.CircuitBreakerSettings
+namespace Dodo.HttpClientResiliencePolicies.CircuitBreakerSettings
 {
 	public class CircuitBreakerSettings : ICircuitBreakerSettings
 	{

--- a/src/Dodo.HttpClient.ResiliencePolicies/CircuitBreakerSettings/ICircuitBreakerSettings.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies/CircuitBreakerSettings/ICircuitBreakerSettings.cs
@@ -2,7 +2,7 @@ using System;
 using System.Net.Http;
 using Polly;
 
-namespace Dodo.HttpClient.ResiliencePolicies.CircuitBreakerSettings
+namespace Dodo.HttpClientResiliencePolicies.CircuitBreakerSettings
 {
 	public interface ICircuitBreakerSettings
 	{

--- a/src/Dodo.HttpClient.ResiliencePolicies/Defaults.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies/Defaults.cs
@@ -1,4 +1,4 @@
-namespace Dodo.HttpClient.ResiliencePolicies
+namespace Dodo.HttpClientResiliencePolicies
 {
 	public static class Defaults
 	{

--- a/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
+++ b/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
@@ -3,7 +3,8 @@
     <TargetFrameworks Condition="'$(Framework)' != 'netcoreapp2.1'">netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <TargetFramework Condition="'$(Framework)' == 'netcoreapp2.1'">netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
-    <VersionPrefix>1.0.3</VersionPrefix>
+    <VersionPrefix>2.0.0</VersionPrefix>
+    <RootNamespace>Dodo.HttpClientResiliencePolicies</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />

--- a/src/Dodo.HttpClient.ResiliencePolicies/HttpClientBuilderExtensions.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies/HttpClientBuilderExtensions.cs
@@ -2,8 +2,8 @@ using System;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using Dodo.HttpClient.ResiliencePolicies.CircuitBreakerSettings;
-using Dodo.HttpClient.ResiliencePolicies.RetrySettings;
+using Dodo.HttpClientResiliencePolicies.CircuitBreakerSettings;
+using Dodo.HttpClientResiliencePolicies.RetrySettings;
 using Microsoft.Extensions.DependencyInjection;
 using Polly;
 using Polly.CircuitBreaker;
@@ -11,7 +11,7 @@ using Polly.Extensions.Http;
 using Polly.Registry;
 using Polly.Timeout;
 
-namespace Dodo.HttpClient.ResiliencePolicies
+namespace Dodo.HttpClientResiliencePolicies
 {
 	/// <summary>
 	/// Extension methods for configuring <see cref="IHttpClientBuilder"/> with Polly retry, timeout, circuit breaker policies.
@@ -30,7 +30,7 @@ namespace Dodo.HttpClient.ResiliencePolicies
 			string clientName = null) where TClientInterface : class
 			where TClientImplementation : class, TClientInterface
 		{
-			Action<System.Net.Http.HttpClient> defaultClient = (client) =>
+			Action<HttpClient> defaultClient = (client) =>
 			{
 				client.BaseAddress = baseAddress;
 				client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/Dodo.HttpClient.ResiliencePolicies/HttpClientSettings.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies/HttpClientSettings.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using Dodo.HttpClient.ResiliencePolicies.CircuitBreakerSettings;
-using Dodo.HttpClient.ResiliencePolicies.RetrySettings;
+using Dodo.HttpClientResiliencePolicies.CircuitBreakerSettings;
+using Dodo.HttpClientResiliencePolicies.RetrySettings;
 
-namespace Dodo.HttpClient.ResiliencePolicies
+namespace Dodo.HttpClientResiliencePolicies
 {
 	public class HttpClientSettings
 	{
@@ -17,7 +17,7 @@ namespace Dodo.HttpClient.ResiliencePolicies
 			TimeSpan timeoutPerTry,
 			int retryCount) : this(httpClientTimeout, timeoutPerTry,
 			new JitterRetrySettings(retryCount),
-			ResiliencePolicies.CircuitBreakerSettings.CircuitBreakerSettings.Default())
+			HttpClientResiliencePolicies.CircuitBreakerSettings.CircuitBreakerSettings.Default())
 		{
 		}
 
@@ -46,7 +46,7 @@ namespace Dodo.HttpClient.ResiliencePolicies
 		public static HttpClientSettings Default() =>
 			new HttpClientSettings(
 				JitterRetrySettings.Default(),
-				ResiliencePolicies.CircuitBreakerSettings.CircuitBreakerSettings.Default()
+				HttpClientResiliencePolicies.CircuitBreakerSettings.CircuitBreakerSettings.Default()
 			);
 	}
 }

--- a/src/Dodo.HttpClient.ResiliencePolicies/RetrySettings/IRetrySettings.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies/RetrySettings/IRetrySettings.cs
@@ -2,7 +2,7 @@ using System;
 using System.Net.Http;
 using Polly;
 
-namespace Dodo.HttpClient.ResiliencePolicies.RetrySettings
+namespace Dodo.HttpClientResiliencePolicies.RetrySettings
 {
 	public interface IRetrySettings
 	{

--- a/src/Dodo.HttpClient.ResiliencePolicies/RetrySettings/JitterRetrySettings.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies/RetrySettings/JitterRetrySettings.cs
@@ -4,7 +4,7 @@ using System.Net.Http;
 using Polly;
 using Polly.Contrib.WaitAndRetry;
 
-namespace Dodo.HttpClient.ResiliencePolicies.RetrySettings
+namespace Dodo.HttpClientResiliencePolicies.RetrySettings
 {
 	public class JitterRetrySettings : IRetrySettings
 	{

--- a/src/Dodo.HttpClient.ResiliencePolicies/RetrySettings/SimpleRetrySettings.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies/RetrySettings/SimpleRetrySettings.cs
@@ -2,7 +2,7 @@
 using System.Net.Http;
 using Polly;
 
-namespace Dodo.HttpClient.ResiliencePolicies.RetrySettings
+namespace Dodo.HttpClientResiliencePolicies.RetrySettings
 {
 	public class SimpleRetrySettings : IRetrySettings
 	{


### PR DESCRIPTION
[*] Change root namespace to avoid namespace clash with `System.Net.Http.HttpClient`. Root namespace is changed from `Dodo.HttpClient.ResiliencePolicies` to `Dodo.HttpClientResiliencePolicies`. The name of the NuGet package and csproj files are not changed. 

Closes #32 