### PR TITLE
Make CircuitBreaker host specific by default

### DIFF
--- a/src/Dodo.HttpClient.ResiliencePolicies.Tests/CircuitBreakerPolicyTests.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies.Tests/CircuitBreakerPolicyTests.cs
@@ -43,7 +43,6 @@ namespace Dodo.HttpClientResiliencePolicies.Tests
 				SleepDurationProvider.Constant(retryCount, TimeSpan.FromMilliseconds(50)));
 
 			var circuitBreakerSettings = BuildCircuitBreakerSettings(minimumThroughput);
-			circuitBreakerSettings.IsHostSpecificOn = true;
 			var wrapper = Create.HttpClientWrapperWrapperBuilder
 				.WithHostAndStatusCode("ru-prod.com", HttpStatusCode.ServiceUnavailable)
 				.WithHostAndStatusCode("ee-prod.com", HttpStatusCode.OK)

--- a/src/Dodo.HttpClient.ResiliencePolicies/CircuitBreakerPolicy/CircuitBreakerPolicySettings.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies/CircuitBreakerPolicy/CircuitBreakerPolicySettings.cs
@@ -15,8 +15,6 @@ namespace Dodo.HttpClientResiliencePolicies.CircuitBreakerPolicy
 		public Action OnReset { get; set; }
 		public Action OnHalfOpen { get; set; }
 
-		public bool IsHostSpecificOn { get; set; }
-
 		public CircuitBreakerPolicySettings()
 			: this(
 				Defaults.CircuitBreaker.FailureThreshold,

--- a/src/Dodo.HttpClient.ResiliencePolicies/CircuitBreakerPolicy/ICircuitBreakerPolicySettings.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies/CircuitBreakerPolicy/ICircuitBreakerPolicySettings.cs
@@ -14,7 +14,5 @@ namespace Dodo.HttpClientResiliencePolicies.CircuitBreakerPolicy
 		Action<DelegateResult<HttpResponseMessage>, TimeSpan> OnBreak { get; set; }
 		Action OnReset { get; set; }
 		Action OnHalfOpen { get; set; }
-
-		bool IsHostSpecificOn { get; set; }
 	}
 }


### PR DESCRIPTION
I got rid of `IsHostSpecificOn` property. CircuitBreaker is always host specific now. It allows us to avoid support of two branches of policies, but we pay a bit with performance. I think we can live with this while we haven't arguments why we shouldn't do that.

Closes #44.