### PR TITLE
Add net5 target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,9 @@ jobs:
     strategy:
       matrix:
         dotnet: [
-          { framework: netcoreapp2.1, version: 2.1.806 },
-          { framework: netcoreapp3.1, version: 3.1.202 }
+          { framework: netcoreapp2.1, version: 2.1.x },
+          { framework: netcoreapp3.1, version: 3.1.x },
+          { framework: net5, version: 5.0.x },
         ]
 
     name: ${{ matrix.dotnet.framework }} – run tests

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -12,8 +12,9 @@ jobs:
     strategy:
       matrix:
         dotnet: [
-          { framework: netcoreapp2.1, version: 2.1.806 },
-          { framework: netcoreapp3.1, version: 3.1.202 }
+          { framework: netcoreapp2.1, version: 2.1.x },
+          { framework: netcoreapp3.1, version: 3.1.x },
+          { framework: net5, version: 5.0.x },
         ]
 
     name: ${{ matrix.dotnet.framework }} – run tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,9 @@ jobs:
     strategy:
       matrix:
         dotnet: [
-        { framework: netcoreapp2.1, version: 2.1.806 },
-        { framework: netcoreapp3.1, version: 3.1.202 }
+          { framework: netcoreapp2.1, version: 2.1.x },
+          { framework: netcoreapp3.1, version: 3.1.x },
+          { framework: net5, version: 5.0.x },
         ]
 
     name: ${{ matrix.dotnet.framework }} – run tests
@@ -62,7 +63,7 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.202
+          dotnet-version: 5.0.x
 
       - name: Build and publish library to NuGet
         run: |

--- a/src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj
+++ b/src/Dodo.HttpClient.ResiliencePolicies.Tests/Dodo.HttpClient.ResiliencePolicies.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(Framework)' != 'netcoreapp2.1'">netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(Framework)' != 'netcoreapp2.1'">netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <TargetFramework Condition="'$(Framework)' == 'netcoreapp2.1'">netcoreapp2.1</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <IsPackable>false</IsPackable>
@@ -9,11 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
     <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Dodo.HttpClient.ResiliencePolicies.Tests/Helper.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies.Tests/Helper.cs
@@ -12,7 +12,7 @@ namespace Dodo.HttpClientResiliencePolicies.Tests
 			var tasks = new Task[taskCount];
 			for (var i = 0; i < taskCount; i++)
 			{
-				var requestMessage = new HttpRequestMessage(HttpMethod.Get, uri);
+				using var requestMessage = new HttpRequestMessage(HttpMethod.Get, uri);
 				requestMessage.Headers.Add("TaskId", i.ToString());
 				tasks[i] = client.SendAsync(requestMessage);
 			}

--- a/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
+++ b/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(Framework)' != 'netcoreapp2.1'">netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(Framework)' != 'netcoreapp2.1'">netstandard2.0;netcoreapp3.1;net5</TargetFrameworks>
     <TargetFramework Condition="'$(Framework)' == 'netcoreapp2.1'">netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <VersionPrefix>2.0.0</VersionPrefix>
@@ -8,11 +8,11 @@
     <Title>Dodo.HttpClient.ResiliencePolicies</Title>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="2.1.1" />
-    <PackageReference Include="Polly" Version="7.2.0" />
-    <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="5.0.0" />
+    <PackageReference Include="Polly" Version="7.2.1" />
+    <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\images\dodopizza-logo.png">


### PR DESCRIPTION
Today net5 is finally released and we have to support it.
[+] Add `net5` target for the library along with `netstandard2.0` and `netcoreapp3.1` targets.
[+] Update project dependencies
[\*] Update CI pipelines to run tests against `net5` along with `netcoreapp2.1` and `netcoreapp3.1`. 

Closes #53.