### PR TITLE
Fix missing .net 5 SDK in LGTM build machines

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,0 +1,5 @@
+extraction:
+  csharp:
+    index:
+      dotnet:
+        version: 5.0.x

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -2,4 +2,4 @@ extraction:
   csharp:
     index:
       dotnet:
-        version: 5.0.x
+        version: 5.0.100


### PR DESCRIPTION
[+] Add `lgtm.yml` to target .net5.0 explicitly.