### PR TITLE
Remove lgtm config

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,5 +1,0 @@
-extraction:
-  csharp:
-    index:
-      dotnet:
-        version: 5.0.100


### PR DESCRIPTION
Remove LGTM config which specifies net5, because it was added by default.