### PR TITLE
Additional break condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Also you may check the [defaults](src/Dodo.HttpClient.ResiliencePolicies/Default
         OnBreak = (response, time) => { ... },      // Handle CircuitBreaker break event. For example you may add logging here
         OnReset = () => {...},                      // Handle CircuitBreaker reset event. For example you may add logging here
         OnHalfOpen = () => {...},                   // Handle CircuitBreaker reset event. For example you may add logging here
+        AdditionalFailureResultFilter = r => false  // Additional condition for CircuitBreaker to open (opens on TooManyRequests by default)
     }
     ```
 

--- a/README.md
+++ b/README.md
@@ -93,11 +93,11 @@ Also you may check the [defaults](src/Dodo.HttpClient.ResiliencePolicies/Default
             durationOfBreak: TimeSpan.FromSeconds(5),
             samplingDuration: TimeSpan.FromSeconds(30)
         ),
-        OnRetry = (response, time) => { ... },      // Handle retry event. For example you may add logging here
-        OnBreak = (response, time) => { ... },      // Handle CircuitBreaker break event. For example you may add logging here
-        OnReset = () => {...},                      // Handle CircuitBreaker reset event. For example you may add logging here
-        OnHalfOpen = () => {...},                   // Handle CircuitBreaker reset event. For example you may add logging here
-        AdditionalFailureResultFilter = r => false  // Additional condition for CircuitBreaker to open (opens on TooManyRequests by default)
+        OnRetry = (response, time) => { ... },                  // Handle retry event. For example you may add logging here
+        OnBreak = (response, time) => { ... },                  // Handle CircuitBreaker break event. For example you may add logging here
+        OnReset = () => {...},                                  // Handle CircuitBreaker reset event. For example you may add logging here
+        OnHalfOpen = () => {...},                               // Handle CircuitBreaker reset event. For example you may add logging here
+        ExtraBreakCondition = BreakConditions.OnTooManyRequests // Extra condition for CircuitBreaker to open (opens on TooManyRequests by default)
     }
     ```
 

--- a/src/Dodo.HttpClient.ResiliencePolicies.Tests/CircuitBreakerPolicyTests.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies.Tests/CircuitBreakerPolicyTests.cs
@@ -73,7 +73,7 @@ namespace Dodo.HttpClientResiliencePolicies.Tests
 				OverallTimeout = TimeSpan.FromSeconds(5),
 				RetryPolicySettings = RetryPolicySettings.Constant(retryCount, TimeSpan.FromMilliseconds(100)),
 				CircuitBreakerPolicySettings = BuildCircuitBreakerSettings(minimumThroughput),
-				AdditionalFailureResultFilter = _ => false, // no additional filter (default is true for 429)
+				ExtraBreakCondition = BreakConditions.None
 			};
 			var wrapper = Create.HttpClientWrapperWrapperBuilder
 				.WithStatusCode(HttpStatusCode.TooManyRequests)

--- a/src/Dodo.HttpClient.ResiliencePolicies/CircuitBreakerPolicy/BreakConditions.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies/CircuitBreakerPolicy/BreakConditions.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Net;
+using System.Net.Http;
+
+namespace Dodo.HttpClientResiliencePolicies.CircuitBreakerPolicy
+{
+	public static class BreakConditions
+	{
+		public static readonly Func<HttpResponseMessage, bool> OnTooManyRequests = response =>
+			response.StatusCode == (HttpStatusCode)429; // Too Many Requests
+		public static readonly Func<HttpResponseMessage, bool> None = _ => false;
+	}
+}

--- a/src/Dodo.HttpClient.ResiliencePolicies/CircuitBreakerPolicy/CircuitBreakerPolicySettings.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies/CircuitBreakerPolicy/CircuitBreakerPolicySettings.cs
@@ -15,7 +15,7 @@ namespace Dodo.HttpClientResiliencePolicies.CircuitBreakerPolicy
 		internal Action<DelegateResult<HttpResponseMessage>, TimeSpan> OnBreak { get; set; }
 		internal Action OnReset { get; set; }
 		internal Action OnHalfOpen { get; set; }
-		internal Func<HttpResponseMessage, bool> AdditionalFailureResultFilter { get; set; }
+		internal Func<HttpResponseMessage, bool> ExtraBreakCondition { get; set; }
 
 		public CircuitBreakerPolicySettings()
 			: this(
@@ -40,13 +40,11 @@ namespace Dodo.HttpClientResiliencePolicies.CircuitBreakerPolicy
 			OnBreak = DoNothingOnBreak;
 			OnReset = DoNothingOnReset;
 			OnHalfOpen = DoNothingOnHalfOpen;
-			AdditionalFailureResultFilter = HandleTooManyRequests;
+			ExtraBreakCondition = BreakConditions.OnTooManyRequests;
 		}
 
 		private static readonly Action<DelegateResult<HttpResponseMessage>, TimeSpan> DoNothingOnBreak = (_, __) => { };
 		private static readonly Action DoNothingOnReset = () => { };
 		private static readonly Action DoNothingOnHalfOpen = () => { };
-		private static readonly Func<HttpResponseMessage, bool> HandleTooManyRequests = response =>
-			response.StatusCode == (HttpStatusCode)429; // Too Many Requests
 	}
 }

--- a/src/Dodo.HttpClient.ResiliencePolicies/CircuitBreakerPolicy/CircuitBreakerPolicySettings.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies/CircuitBreakerPolicy/CircuitBreakerPolicySettings.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Net;
 using System.Net.Http;
 using Polly;
 

--- a/src/Dodo.HttpClient.ResiliencePolicies/CircuitBreakerPolicy/CircuitBreakerPolicySettings.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies/CircuitBreakerPolicy/CircuitBreakerPolicySettings.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net;
 using System.Net.Http;
 using Polly;
 
@@ -14,6 +15,7 @@ namespace Dodo.HttpClientResiliencePolicies.CircuitBreakerPolicy
 		internal Action<DelegateResult<HttpResponseMessage>, TimeSpan> OnBreak { get; set; }
 		internal Action OnReset { get; set; }
 		internal Action OnHalfOpen { get; set; }
+		internal Func<HttpResponseMessage, bool> AdditionalFailureResultFilter { get; set; }
 
 		public CircuitBreakerPolicySettings()
 			: this(
@@ -38,10 +40,13 @@ namespace Dodo.HttpClientResiliencePolicies.CircuitBreakerPolicy
 			OnBreak = DoNothingOnBreak;
 			OnReset = DoNothingOnReset;
 			OnHalfOpen = DoNothingOnHalfOpen;
+			AdditionalFailureResultFilter = HandleTooManyRequests;
 		}
 
 		private static readonly Action<DelegateResult<HttpResponseMessage>, TimeSpan> DoNothingOnBreak = (_, __) => { };
 		private static readonly Action DoNothingOnReset = () => { };
 		private static readonly Action DoNothingOnHalfOpen = () => { };
+		private static readonly Func<HttpResponseMessage, bool> HandleTooManyRequests = response =>
+			response.StatusCode == (HttpStatusCode)429; // Too Many Requests
 	}
 }

--- a/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
+++ b/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
@@ -6,7 +6,7 @@
     <TargetFramework Condition="'$(Framework)' == 'net5.0'">net5.0</TargetFramework>
     <TargetFramework Condition="'$(Framework)' == 'netcoreapp3.1'">netcoreapp3.1</TargetFramework>
     <LangVersion>8.0</LangVersion>
-    <VersionPrefix>2.0.2</VersionPrefix>
+    <VersionPrefix>2.0.3</VersionPrefix>
     <Title>Dodo.HttpClient.ResiliencePolicies</Title>
     <RootNamespace>Dodo.HttpClientResiliencePolicies</RootNamespace>
     <WarningsAsErrors>true</WarningsAsErrors>

--- a/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
+++ b/src/Dodo.HttpClient.ResiliencePolicies/Dodo.HttpClient.ResiliencePolicies.csproj
@@ -6,7 +6,7 @@
     <TargetFramework Condition="'$(Framework)' == 'net5.0'">net5.0</TargetFramework>
     <TargetFramework Condition="'$(Framework)' == 'netcoreapp3.1'">netcoreapp3.1</TargetFramework>
     <LangVersion>8.0</LangVersion>
-    <VersionPrefix>2.0.3</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <Title>Dodo.HttpClient.ResiliencePolicies</Title>
     <RootNamespace>Dodo.HttpClientResiliencePolicies</RootNamespace>
     <WarningsAsErrors>true</WarningsAsErrors>

--- a/src/Dodo.HttpClient.ResiliencePolicies/PoliciesHttpClientBuilderExtensions.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies/PoliciesHttpClientBuilderExtensions.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Net;
 using System.Net.Http;
 using Dodo.HttpClientResiliencePolicies.CircuitBreakerPolicy;
 using Dodo.HttpClientResiliencePolicies.RetryPolicy;

--- a/src/Dodo.HttpClient.ResiliencePolicies/PoliciesHttpClientBuilderExtensions.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies/PoliciesHttpClientBuilderExtensions.cs
@@ -80,7 +80,7 @@ namespace Dodo.HttpClientResiliencePolicies
 			return HttpPolicyExtensions
 				.HandleTransientHttpError()
 				.Or<TimeoutRejectedException>()
-				.OrResult(settings.AdditionalFailureResultFilter)
+				.OrResult(settings.ExtraBreakCondition)
 				.AdvancedCircuitBreakerAsync(settings);
 		}
 

--- a/src/Dodo.HttpClient.ResiliencePolicies/PoliciesHttpClientBuilderExtensions.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies/PoliciesHttpClientBuilderExtensions.cs
@@ -80,7 +80,7 @@ namespace Dodo.HttpClientResiliencePolicies
 			return HttpPolicyExtensions
 				.HandleTransientHttpError()
 				.Or<TimeoutRejectedException>()
-				.OrResult(r => r.StatusCode == (HttpStatusCode) 429) // Too Many Requests
+				.OrResult(settings.AdditionalFailureResultFilter)
 				.AdvancedCircuitBreakerAsync(settings);
 		}
 

--- a/src/Dodo.HttpClient.ResiliencePolicies/ResiliencePoliciesSettings.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies/ResiliencePoliciesSettings.cs
@@ -44,11 +44,13 @@ namespace Dodo.HttpClientResiliencePolicies
 				var onBreakHandler = OnBreak;
 				var onResetHandler = OnReset;
 				var onHalfOpenHandler = OnHalfOpen;
+				var additionalFailureResultFilter = AdditionalFailureResultFilter;
 
 				_circuitBreakerPolicySettings = value;
 				_circuitBreakerPolicySettings.OnBreak = onBreakHandler;
 				_circuitBreakerPolicySettings.OnReset = onResetHandler;
 				_circuitBreakerPolicySettings.OnHalfOpen = onHalfOpenHandler;
+				_circuitBreakerPolicySettings.AdditionalFailureResultFilter = additionalFailureResultFilter;
 			}
 		}
 
@@ -74,6 +76,12 @@ namespace Dodo.HttpClientResiliencePolicies
 		{
 			get => CircuitBreakerPolicySettings.OnHalfOpen;
 			set => CircuitBreakerPolicySettings.OnHalfOpen = value;
+		}
+
+		public Func<HttpResponseMessage, bool> AdditionalFailureResultFilter
+		{
+			get => CircuitBreakerPolicySettings.AdditionalFailureResultFilter;
+			set => CircuitBreakerPolicySettings.AdditionalFailureResultFilter = value;
 		}
 	}
 }

--- a/src/Dodo.HttpClient.ResiliencePolicies/ResiliencePoliciesSettings.cs
+++ b/src/Dodo.HttpClient.ResiliencePolicies/ResiliencePoliciesSettings.cs
@@ -44,13 +44,13 @@ namespace Dodo.HttpClientResiliencePolicies
 				var onBreakHandler = OnBreak;
 				var onResetHandler = OnReset;
 				var onHalfOpenHandler = OnHalfOpen;
-				var additionalFailureResultFilter = AdditionalFailureResultFilter;
+				var extraBreakCondition = ExtraBreakCondition;
 
 				_circuitBreakerPolicySettings = value;
 				_circuitBreakerPolicySettings.OnBreak = onBreakHandler;
 				_circuitBreakerPolicySettings.OnReset = onResetHandler;
 				_circuitBreakerPolicySettings.OnHalfOpen = onHalfOpenHandler;
-				_circuitBreakerPolicySettings.AdditionalFailureResultFilter = additionalFailureResultFilter;
+				_circuitBreakerPolicySettings.ExtraBreakCondition = extraBreakCondition;
 			}
 		}
 
@@ -78,10 +78,10 @@ namespace Dodo.HttpClientResiliencePolicies
 			set => CircuitBreakerPolicySettings.OnHalfOpen = value;
 		}
 
-		public Func<HttpResponseMessage, bool> AdditionalFailureResultFilter
+		public Func<HttpResponseMessage, bool> ExtraBreakCondition
 		{
-			get => CircuitBreakerPolicySettings.AdditionalFailureResultFilter;
-			set => CircuitBreakerPolicySettings.AdditionalFailureResultFilter = value;
+			get => CircuitBreakerPolicySettings.ExtraBreakCondition;
+			set => CircuitBreakerPolicySettings.ExtraBreakCondition = value;
 		}
 	}
 }


### PR DESCRIPTION
In some cases we need to pass 429 status code to clients and do not open circuit breaker.
So I added a `ExtraBreakCondition ` setting in `ResiliencePoliciesSettings` to override default condition to break on 429 status code 